### PR TITLE
Dome Viewer - Menu Conformity

### DIFF
--- a/projects/DomeViewer/Assets/Modules/UI/Prefabs/Sets/Container - Dome Settings.prefab
+++ b/projects/DomeViewer/Assets/Modules/UI/Prefabs/Sets/Container - Dome Settings.prefab
@@ -86,7 +86,7 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_IsOn: 1
+  m_IsOn: 0
 --- !u!1 &3076083441315904894
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Minor Change that sets the default toggle for Star Projector to off in it's prefab, as currently the App starts with a turned off Star Projector