### PR TITLE
limit player to domeradius

### DIFF
--- a/projects/DomeViewer/Assets/Modules/BasicInteraction/LimitPlayerDomeRadius.cs
+++ b/projects/DomeViewer/Assets/Modules/BasicInteraction/LimitPlayerDomeRadius.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.XR.CoreUtils;
+using UnityEngine;
+
+namespace pfc.Fulldome
+{
+    public class LimitPlayerDomeRadius : MonoBehaviour
+    {
+        [SerializeField]
+        public float allowedRadius = 15f;
+        
+        [SerializeField]
+        XROrigin XrPlayer = null;
+
+        // Update is called once per frame
+        void Update()
+        {
+            if (XrPlayer == null){return;}
+            Vector3 directionToPlayer = XrPlayer.transform.position - transform.position;
+            float distanceToPlayer = directionToPlayer.magnitude;
+
+            if (distanceToPlayer > allowedRadius){
+                Vector3 clampedPosition = transform.position + directionToPlayer.normalized * allowedRadius;
+                XrPlayer.transform.position = clampedPosition;
+            }
+        }
+    }
+}

--- a/projects/DomeViewer/Assets/Modules/BasicInteraction/LimitPlayerDomeRadius.cs.meta
+++ b/projects/DomeViewer/Assets/Modules/BasicInteraction/LimitPlayerDomeRadius.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 598c8c68e38fc6f4fae257c1584ca32e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/projects/DomeViewer/Assets/Modules/Inputs/LimitPlayerDomeRadius.prefab
+++ b/projects/DomeViewer/Assets/Modules/Inputs/LimitPlayerDomeRadius.prefab
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6028094659895859585
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6028094659895859584}
+  - component: {fileID: 6028094659895859591}
+  m_Layer: 0
+  m_Name: LimitPlayerDomeRadius
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6028094659895859584
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6028094659895859585}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6028094659895859591
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6028094659895859585}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 598c8c68e38fc6f4fae257c1584ca32e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  allowedRadius: 15
+  XrPlayer: {fileID: 0}

--- a/projects/DomeViewer/Assets/Modules/Inputs/LimitPlayerDomeRadius.prefab.meta
+++ b/projects/DomeViewer/Assets/Modules/Inputs/LimitPlayerDomeRadius.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b96776cccb918c94fad4551a6add0b8f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adding a script for limiting the player to the dome radius preventing "beeing outside the dome".
Every domesize has a prefab with the script setting up the radius (should be a little bit smaller than original domesize to prevent standing in the wall).