### PR TITLE
Add support for 3K and 6K to the Dome Render Texture

### DIFF
--- a/package/Editor/DomeRendererEditor.cs
+++ b/package/Editor/DomeRendererEditor.cs
@@ -260,7 +260,7 @@ namespace pfc.DomeTools
                 }
                 EditorGUI.BeginDisabledGroup(!canBeEdited);
                 var size = Mathf.Min(rt.width, rt.height);
-                var newSize = EditorGUILayout.IntPopup("Size", size, new[] { "128", "256", "512", "1024", "2048", "4096", "8192" }, new[] { 128, 256, 512, 1024, 2048, 4096, 8192 });
+                var newSize = EditorGUILayout.IntPopup("Size", size, new[] { "128", "256", "512", "1024", "2048", "3072", "4096", "6144", "8192" }, new[] { 128, 256, 512, 1024, 2048,3072, 4096, 6144, 8192 });
                 if (EditorGUI.EndChangeCheck())
                 {
                     rt.Release();


### PR DESCRIPTION
Altered the dropdown inside of DomeRendererEditor.cs to allow for 3072x3072 and 6144x6144 render texture sizes.